### PR TITLE
Fixed typo in regularization section

### DIFF
--- a/Lecture02_Regularization/Lecture 02 - Regularization.ipynb
+++ b/Lecture02_Regularization/Lecture 02 - Regularization.ipynb
@@ -63,7 +63,7 @@
     "\n",
     "* Suppose you have data that you fit a model to, how do you know if you have overfit and/or underfit?  *What is Cross Validation?*\n",
     "\n",
-    "* Lets look back our polynomial curve fitting code. \n",
+    "* Lets look back at our polynomial curve fitting code. \n",
     "    * What happens to the weight $\\mathbf{w}$ when we overfit? \n",
     "    * Are we more likely to overfit with more or less data? Why?\n"
    ]
@@ -297,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed a typo in regularization section.

Also, the .ipynb file auto-updated my python version above what is checked in.  I think this may be the culprit to everyone's .ipynb showing a change when we didn't actually change anything.  You can reject that change if you'd like, but I think it would be nice to be on the same version. 