### PR TITLE
minor mistake about universal appoximation?

### DIFF
--- a/Lecture17_Backpropagation/Lecture 17 - Backpropagation.ipynb
+++ b/Lecture17_Backpropagation/Lecture 17 - Backpropagation.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Universal Approximation Theorem: \n",
     "\n",
-    "Let $\\phi(\\cdot)$ be a non-constant, bounded and monotone-increasing continuous function.  Let $I_{m_0}$ denote the $m_0$-dimensional unit hypercube $[0, 1]^{m_0}$.  The space of continuous functions on $I_{m_0}$ is denoted by $C(I_{m_0})$.  Then, given any function $f \\ni C(I_{m_0})$ and $\\epsilon > 0$, there exists an integer $m_1$ and sets of real constants $\\alpha_i, \\beta_i,$ and $w_{ij}$, where $i = 1, \\ldots, m_1$ and $j = 1, \\ldots, m_0$ such that we may define\n",
+    "Let $\\phi(\\cdot)$ be a non-constant, bounded and monotone-increasing continuous function.  Let $I_{m_0}$ denote the $m_0$-dimensional unit hypercube $[0, 1]^{m_0}$.  The space of continuous functions on $I_{m_0}$ is denoted by $C(I_{m_0})$.  Then, given any function $f \\in C(I_{m_0})$ and $\\epsilon > 0$, there exists an integer $m_1$ and sets of real constants $\\alpha_i, \\beta_i,$ and $w_{ij}$, where $i = 1, \\ldots, m_1$ and $j = 1, \\ldots, m_0$ such that we may define\n",
     "\\begin{equation}\n",
     "F(x_1, \\ldots, x_{m_0}) = \\sum_{i=1}^{m_1} \\alpha_i \\phi\\left( \\sum_{j=1}^{m_0} w_{ij}x_j + b_i\\right)\n",
     "\\end{equation}\n",
@@ -14,7 +14,7 @@
     "\\begin{equation}\n",
     "\\left| F(x_1, \\ldots, x_{m_0}) - f(x_1, \\ldots, x_{m_0}) \\right| < \\epsilon\n",
     "\\end{equation}\n",
-    "for all $x_1, x_2, \\ldots, x_{m_0}$ that like in the input space.}}\n",
+    "for all $x_1, x_2, \\ldots, x_{m_0}$ in the input space.\n",
     "\n",
     "* Essentially, the Universal Approximation Theorem states that a single hidden layer is sufficient for a multilayer perceptron to compute a uniform $\\epsilon$ approximation to a given training set - provided you have the *right* number of neurons and the *right* activation function.  (However, this does not say that a single hidden layer is optimal with regards to learning time, generalization, etc.)  \n",
     "\n"
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Background for Error Back-Propagation}\n",
+    "## Background for Error Back-Propagation\n",
     "\n",
     "* Error Back-Propagation is based on *gradient descent*.\n",
     "* Let's review/learn gradient descent:\n",
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Is it a mistake or a different written formula? I see both versions online.
AND why isn't this covered in class?
![before](https://user-images.githubusercontent.com/18255446/47608744-786c0380-da00-11e8-98f9-3e31e2580581.png)
![after](https://user-images.githubusercontent.com/18255446/47608745-7ace5d80-da00-11e8-99bb-6eb3fbdd4837.png)
